### PR TITLE
Add configuration functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **__pycache__**
 wandb/*
 *ckpt*
+*onnx*

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,26 @@
+[dataset]
+dset_dir = ../data/Others/Histological_images_MSI_vs_MSS
+dset_mean = [0.7263, 0.5129, 0.6925]
+dset_std = [0.1444, 0.1833, 0.131]
+
+[model]
+resnet_layers = 50
+pretrained = True
+load_weights_path = None
+
+[trainer]
+val_prop = 0.20
+batch_size = 128
+max_epochs = 2
+optim = torch.optim.Adam
+lr = 1e-3
+pretrained = True
+num_gpus = -1
+freeze = True
+unfreeze = 2
+
+[logger]
+project = ts-tl
+group_name = MSI_vs_MSS
+run_name = pretrained2
+model_name = MSI_vs_MSS_resnet50_pretrained.ckpt

--- a/datamodules/datafolders.py
+++ b/datamodules/datafolders.py
@@ -46,7 +46,8 @@ class DataFolders(pl.LightningDataModule):
         Args:
             data_dir (str, optional): Location of the image folders. Defaults to './'.
             batch_size (int, optional): Batch size. Defaults to 64.
-            val_prop (float, optional): Proportion of the dataset to include in the validation split. Defaults to 0.2.
+            val_prop (float, optional): Proportion of the dataset to include in the
+                validation split. Defaults to 0.2.
             dset_mean (list): Dataset mean values. Defaults to None.
             dset_std (list): Dataset standard deviation values. Defaults to None
         """
@@ -119,6 +120,9 @@ class DataFolders(pl.LightningDataModule):
             # select the subsets based on train_test_splits and appropriate dsets:
             self.dm_train = Subset(self.dset, x_ind_train)
             self.dm_val = Subset(dset_val, x_ind_val)
+
+            print(f'Train len: {len(self.dm_train)}')
+            print(f'Val len: {len(self.dm_val)}')
 
         if stage == 'test' or stage is None:
             self.dset_test = ImageFolder(os.path.join(self.data_dir, 'test'),


### PR DESCRIPTION
The main `cnn_trainer.py` script now works by reading a [configuration file](https://docs.python.org/3/library/configparser.html). Most of the necessary options can be modified through the configuration file. With this modification, `cnn_trainer.py` will read a file named `config.ini` located in the same folder.